### PR TITLE
Phptest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,5 +12,13 @@
             "email": "l@pnx.me"
         }
     ],
-    "require": {}
+    "require": {
+    },
+    "autoload": {
+      "psr-4": { "RomanNumeralGenerator\\": "src" }
+    },
+    "autoload-dev": {
+      "psr-4": { "RomanNumeralGenerator\\": "tests" }
+    }
 }
+

--- a/src/RomanNumeralGenerator.php
+++ b/src/RomanNumeralGenerator.php
@@ -18,8 +18,34 @@ class RomanNumeralGenerator {
    * @return string
    *   Roman numeral representing the passed integer.
    */
-  public function generate(int $number, bool $lowerCase = FALSE) : string {
-    return "Not implemented";
+    
+    public function generate($number, $lowerCase = false) {
+        
+    // validate if the incoming parameter is a number
+    if(!is_numeric ($number) or $number <= 0) {
+        return "Cannot return a valid Roman for that number";
+    }
+    
+    // Lookup table that contain array keys as Roman numerals and values as the corresponding numbers
+    $lookup = array('M'=>1000, 'CM'=>900, 'D'=>500, 'CD'=>400, 'C'=>100, 'XC'=>90, 'L'=>50, 'XL'=>40, 'X'=>10, 'IX'=>9, 'V'=>5, 'IV'=>4, 'I'=>1); 
+    $roman = ''; 
+    while($number > 0) 
+    { 
+        foreach($lookup as $symbol=>$value) 
+        { 
+            if($number >= $value) 
+            { 
+                $number -= $value; 
+                $roman .= $symbol; 
+                break; 
+            } 
+        } 
+    }
+    // if the parameter for lowercase is specified to TRUE then return as lower case
+    if($lowerCase) {
+        $roman = strtolower($roman);
+    } 
+    return $roman; 
   }
-
+  
 }

--- a/tests/RomanNumeralGeneratorTest.php
+++ b/tests/RomanNumeralGeneratorTest.php
@@ -34,6 +34,16 @@ class RomanNumeralGeneratorTest extends \PHPUnit_Framework_TestCase {
   public function testGeneration($number, $expected) {
     $this->assertEquals($expected, $this->generator->generate($number));
   }
+  
+  
+  /**
+   * Tests roman numeral generation with CASE provided.
+   *
+   * @dataProvider providerTestGenerationwithCase
+   */
+  public function testGenerationWithCase($number, $expected, $lowercase) {
+    $this->assertEquals($expected, $this->generator->generate($number, $lowercase));
+  }
 
   /**
    * Data provider for testGeneration().
@@ -43,6 +53,7 @@ class RomanNumeralGeneratorTest extends \PHPUnit_Framework_TestCase {
    */
   public function providerTestGeneration() {
     return [
+      abcd => ["abcd","Cannot return a valid Roman for that number"],
       1 => [1, "I"],
       2 => [2, "II"],
       3 => [3, "III"],
@@ -62,5 +73,37 @@ class RomanNumeralGeneratorTest extends \PHPUnit_Framework_TestCase {
       1024 => [1024, "MXXIV"],
       3000 => [3000, "MMM"],
     ];
+  }
+  
+  /**
+   * Data provider for testGenerationWithCase().
+   *
+   * @return array
+   *   Test cases.
+   */
+  
+  public function providerTestGenerationwithCase() {
+    return [
+      0 => [0, "Cannot return a valid Roman for that number", true],
+      1 => [1, "i",true],
+      2 => [2, "II",false],
+      3 => [3, "iii",true],
+      4 => [4, "IV",false],
+      5 => [5, "v",true],
+      6 => [6, "vi",true],
+      9 => [9, "IX",false],
+      27 => [27, "xxvii",true],
+      48 => [48, "XLVIII",false],
+      59 => [59, "LIX",false],
+      93 => [93, "XCIII",false],
+      141 => [141, "CXLI",false],
+      163 => [163, "CLXIII",false],
+      402 => [402, "CDII",false],
+      575 => [575, "DLXXV",false],
+      911 => [911, "CMXI",false],
+      1024 => [1024, "MXXIV",false],
+      3000 => [3000, "MMM",false],
+    ];
+    
   }
 }


### PR DESCRIPTION
This PHP Unit test was developed using PHP 5.6.29. Since Type Hinting was supported by PHP versions 7 and above, the definition for generate() in /src/RomanNumneralGenerator() was modified. Moreover, additional validations are done to check if the incoming number is actually a number and greater than 0. 